### PR TITLE
Add support for TCP Kerberos ENC type 0x12 / 18

### DIFF
--- a/Pcredz
+++ b/Pcredz
@@ -242,7 +242,18 @@ def ParseMSKerbv5UDP(Data):
             Domain = Data[HashLen+98+NameLen+4:HashLen+98+NameLen+4+DomainLen]
             BuildHash = "$krb5pa$23$"+Name+"$"+Domain+"$dummy$"+SwitchHash.encode('hex')
             return 'MSKerb hash found: %s\n'%(BuildHash),"$krb5pa$23$"+Name+"$"+Domain+"$dummy$"
-
+    
+    elif MsgType == "\x0a" and EncType == "\x12" and MessageType =="\x02":
+        if Data[44:48] == "\xa2\x3a\x04\x38":
+            HashLen = struct.unpack('<b',Data[47])[0]
+            Hash    = Data[48:48+HashLen]
+            NameLen = struct.unpack('<b',Data[152:153])[0]
+            Name = Data[153:153+NameLen]
+            DomainLen = struct.unpack('<b',Data[153+NameLen+3:153+NameLen+4])[0]
+            Domain = Data[153+NameLen+4:153+NameLen+4+DomainLen]
+            Salt = ""
+            BuildHash = "$krb5pa$18$"+Name+"$"+Domain+"$"+Salt+"$"+Hash.encode('hex')
+            return 'MSKerb hash found: %s\n'%(BuildHash),"$krb5pa$18$"+Name+"$"+Domain+"$"+Salt+"$"   
     else:
         return False
 


### PR DESCRIPTION
I've added support to extract the PA-ENC-TIMESTAMP type 18 (only in TCP). This will be able to extract the hashes from AD-capture-1 and AD-capture-2, as provided by openwall: http://openwall.info/wiki/_media/john/krbv5-pcaps.tar.gz
The code of Jtr shows the passwords: https://github.com/magnumripper/JohnTheRipper/blob/bleeding-jumbo/src/krb5pa-sha1_fmt_plug.c

NOTE: Currently, this will not extract the correct salt!! The salt used in the capture is provided by the KDC in an earlier packet. Since the PCredz code seems to do a packet by packet dissection, the current function won't see the correct salt. Any suggestions would be welcome. I'm sure I've overlooked something.