### PR TITLE
Add a missing comma after 'login_password'

### DIFF
--- a/Pcredz
+++ b/Pcredz
@@ -68,8 +68,8 @@ http_userfields = ['log','login', 'wpname', 'ahd_username', 'unickname', 'nickna
                     'uname', 'ulogin', 'acctname', 'account', 'member', 'mailaddress', 'membername', 'login_username',
                     'login_email', 'loginusername', 'loginemail', 'uin', 'sign-in', 'j_username']
 
-http_passfields = ['ahd_password', 'pass', 'password', '_password', 'passwd', 'session_password', 'sessionpassword', 
-                   'login_password', 'loginpassword', 'form_pw', 'pw', 'userpassword', 'pwd', 'upassword', 'login_password'
+http_passfields = ['ahd_password', 'pass', 'password', '_password', 'passwd', 'session_password', 'sessionpassword',
+                   'login_password', 'loginpassword', 'form_pw', 'pw', 'userpassword', 'pwd', 'upassword', 'login_password',
                    'passwort', 'passwrd', 'wppassword', 'upasswd', 'j_password']
 
 Filename = str(os.path.join(os.path.dirname(__file__),"CredentialDump-Session.log"))


### PR DESCRIPTION
There is no comma after 'login_password', so it will become 'login_passwordpasswort' instead of 'login_password' and 'passwort'