### PR TITLE
Fix HTTP NTLM type 3 output

### DIFF
--- a/Pcredz
+++ b/Pcredz
@@ -585,7 +585,7 @@ def ParseDataRegex(decoded, SrcPort, DstPort, packet_num):
                         if PrintPacket(Filename,Message[1]):
                             l.warning(HeadMessage)
                             l.warning(Message[0])
-                            print HeadMessage+'\n'+Message
+                            print HeadMessage+'\n'+Message[0]
         except:
             pass
 


### PR DESCRIPTION
HTTP NTLM type 3 output tries to print the message tuple as in.

Trying to print a tuple lead to "not all arguments converted during string formatting" error (python 2.7.16):
```Python
>>> a = 1,2
>>> print "%s"%a
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: not all arguments converted during string formatting
```
Therefore, the message with the hash value is not displayed.

Fix this by adding missing brackets.