### PR TITLE
fixing a unicode decoding error I encountered.

### DIFF
--- a/Pcredz
+++ b/Pcredz
@@ -328,7 +328,11 @@ def ParseMSSQLPlainText(data):
 	PwdLen = AppOffset-PwdOffset
 	UsernameLen = PwdOffset-UsernameOffset
 	PwdStr = ParseSqlClearTxtPwd(data[8+PwdOffset:8+PwdOffset+PwdLen])
-	UserName = data[8+UsernameOffset:8+UsernameOffset+UsernameLen].decode('utf-16le')
+	try:
+		UserName = data[8+UsernameOffset:8+UsernameOffset+UsernameLen].decode('utf-16le')
+	except BaseException as e:
+		print("Error decoding:", data, '\n', e)
+
 	WriteData("logs/MSSQL-Plaintext.txt", "MSSQL Username: %s Password: %s"%(UserName, PwdStr), UserName)
 	return "MSSQL Username: %s Password: %s"%(UserName, PwdStr)
 


### PR DESCRIPTION
I was analyzing some traffic I captured and it kept crashing on one particular file. 

The python traceback showed me what was happening. 

I just wrapped the decode in a try block. 

The pcap in question did have mssql traffic. 

This lets me at least capture that something went wrong and shows the data in case I can tease something out of it visually. 