### PR TITLE
Fix decode_file() by using Print_Packet_800dot11()

### DIFF
--- a/Pcredz
+++ b/Pcredz
@@ -726,7 +726,7 @@ def decode_file(fname,res):
 			l.warning('\n\nPcredz started, using:%s file'%(fname))
 			Version = IsCookedPcap(res)
 			if Version == 1:
-				thread = Thread(target = loop_packets, args = (p, Print_Packet_Cooked))
+				thread = Thread(target = loop_packets, args = (p, Print_Packet_800dot11))
 				thread.daemon=True
 				thread.start()
 				try:


### PR DESCRIPTION
Print_Packet_800dot11() is never called. Instead Print_Packet_Cooked() is called when IsCookedPcap() returns 1, which means that is the 802.11 format.

This commit fix it by using Print_Packet_800dot11() when IsCookedPcap returns 1.