### PR TITLE
Parse NTLM from HTTP Negotiate scheme

### DIFF
--- a/Pcredz
+++ b/Pcredz
@@ -392,6 +392,14 @@ def ParseDataRegex(decoded, SrcPort, DstPort):
 		if passw:
 			HTTPass = passw
 
+	HTTPNegotiateAuthz = re.findall(b'(?<=Authorization: Negotiate )[^\\r]*', decoded['data'])
+	if HTTPNegotiateAuthz:
+		decoded['data'] = b64decode(b''.join(HTTPNegotiateAuthz))
+
+	HTTPNegotiateWWW = re.findall(b'(?<=WWW-Authenticate: Negotiate )[^\\r]*', decoded['data'])
+	if HTTPNegotiateWWW:
+		decoded['data'] = b64decode(b''.join(HTTPNegotiateWWW))
+
 	SMTPAuth = re.search(b'AUTH LOGIN|AUTH PLAIN', decoded['data'])
 	Basic64 = re.findall(b'(?<=Authorization: Basic )[^\n]*', decoded['data'])
 	FTPUser = re.findall(b'(?<=USER )[^\r]*', decoded['data'])


### PR DESCRIPTION
Hi !

This PR allows PCredz to obtain NTLM authentication hashes from HTTP using the `Negotiate` scheme.

This works by first base64-decoding the `Negotiate` payload and putting it in the `decoded['data']` variable. The `NTLMSSP2` and `NTLMSSP3` regexes will then pick up the challenge and response if NTLM was used.

Cheers !