### PR TITLE
Option to change output directory

### DIFF
--- a/Pcredz
+++ b/Pcredz
@@ -39,11 +39,13 @@ import codecs
 from base64 import b64decode
 from threading import Thread
 
+PcredzVersion='2.0.2'
+
 def ShowWelcome():
-	Message = 'Pcredz 2.0.2\nAuthor: Laurent Gaffie\nPlease send bugs/comments/pcaps to: laurent.gaffie@gmail.com\nThis script will extract NTLM (HTTP,LDAP,SMB,MSSQL,RPC, etc), Kerberos,\nFTP, HTTP Basic and credit card data from a given pcap file or from a live interface.\n'
+	Message = f'Pcredz {PcredzVersion}\nAuthor: Laurent Gaffie\nPlease send bugs/comments/pcaps to: laurent.gaffie@gmail.com\nThis script will extract NTLM (HTTP,LDAP,SMB,MSSQL,RPC, etc), Kerberos,\nFTP, HTTP Basic and credit card data from a given pcap file or from a live interface.\n'
 	print(Message)
 
-parser = argparse.ArgumentParser(description='Pcredz 1.0.0\nAuthor: Laurent Gaffie')
+parser = argparse.ArgumentParser(description=f'Pcredz {PcredzVersion}\nAuthor: Laurent Gaffie')
 m_group=parser.add_mutually_exclusive_group()
 m_group.add_argument('-f', type=str, dest="fname", default=None, help="Pcap file to parse")
 m_group.add_argument('-d', type=str, dest="dir_path", default=None, help="Pcap directory to parse recursivly")

--- a/Pcredz
+++ b/Pcredz
@@ -53,6 +53,7 @@ m_group.add_argument('-i', type=str, dest="interface", default=None, help="inter
 parser.add_argument('-c', action="store_false", dest="activate_cc", default=True, help="deactivate CC number scanning (Can gives false positives!)")
 parser.add_argument('-t', action="store_true", dest="timestamp", help="Include a timestamp in all generated messages (useful for correlation)")
 parser.add_argument('-v', action="store_true", dest="Verbose", help="More verbose.")
+parser.add_argument('-o', type=str, dest="output_path", default=os.path.abspath(os.path.join(os.path.dirname(__file__)))+"/", help="output directory")
 
 options = parser.parse_args()
 
@@ -70,7 +71,9 @@ activate_cc = options.activate_cc
 timestamp = options.timestamp
 start_time = time.time()
 
-PcredzPath = os.path.abspath(os.path.join(os.path.dirname(__file__)))+"/"
+PcredzPath = options.output_path
+if not PcredzPath.endswith('/'):
+	PcredzPath += '/'
 Filename = PcredzPath+"CredentialDump-Session.log"
 l= logging.getLogger('Credential-Session')
 l.addHandler(logging.FileHandler(Filename,'a'))
@@ -81,6 +84,8 @@ def WriteData(outfile, data, user):
 	if type(user) is str:
 		user = user.encode('latin-1')
 	if not os.path.isfile(outfile):
+		if not os.path.isdir(os.path.dirname(outfile)):
+			os.makedirs(os.path.dirname(outfile))
 		with open(outfile,"w") as outf:
 			outf.write(data + '\n')
 		return

--- a/Readme.md
+++ b/Readme.md
@@ -44,11 +44,12 @@ python3 ./Pcredz -i eth0 -v
 
 ### Options
 
-```bash
+```
   -h, --help          show this help message and exit
   -f capture.pcap     Pcap file to parse
   -d /home/pnt/pcap/  Pcap directory to parse recursivly
   -i eth0             interface for live capture
   -v                  More verbose.
+  -o output_dir       Store log files in output_dir instead of the directory containing Pcredz.
 ```
 


### PR DESCRIPTION
This PR adds an option to store logs in a different directory than the default (which is the directory containing Pcredz itself).
It also corrects an inconsistency in the version numbers given in ShowWelcome() and in the help message.