### PR TITLE
Install "file"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,7 @@ $ docker run --net=host -v $(pwd):/opt/Pcredz -it pcredz
 On a debian based OS bash:
 
 ```bash
-apt install python3-pip && sudo apt-get install libpcap-dev && pip3 install Cython && pip3 install python-libpcap
+apt install python3-pip && sudo apt install libpcap-dev && pip3 install Cython && pip3 install python-libpcap
 ```
 
 ## Usage

--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,7 @@ $ docker run --net=host -v $(pwd):/opt/Pcredz -it pcredz
 On a debian based OS bash:
 
 ```bash
-apt install python3-pip && sudo apt install libpcap-dev && pip3 install Cython && pip3 install python-libpcap
+apt install python3-pip && sudo apt install libpcap-dev && sudo apt install file && pip3 install Cython && pip3 install python-libpcap
 ```
 
 ## Usage

--- a/dockerfile
+++ b/dockerfile
@@ -7,6 +7,7 @@ RUN apt update
 RUN apt install python3 \
     python3-pip \
     libpcap-dev \
+    file \
     nano \
     iproute2 \
     git \


### PR DESCRIPTION
Hi

- PCredz uses the "file" command, but the "file" package which includes this command is not a dependency of other installed packages
- Readme.md : replace "apt-get" by "apt" to be consistent
