### PR TITLE
Regex order for password in HTTP request

### DIFF
--- a/Pcredz
+++ b/Pcredz
@@ -394,7 +394,7 @@ def ParseDataRegex(decoded, SrcPort, DstPort):
 		if user:
 			HTTPUser = user
 
-	HTTPPasswd = re.search(b'ahd_password|pass|password|_password|passwd|session_password|sessionpassword|login_password|loginpassword|form_pw|pw|userpassword|pwd|upassword|login_passwordpasswort|passwrd|wppassword|upasswd|j_password', decoded['data'])
+	HTTPPasswd = re.search(b'ahd_password|password|pass|_password|passwd|session_password|sessionpassword|login_password|loginpassword|form_pw|pw|userpassword|pwd|upassword|login_passwordpasswort|passwrd|wppassword|upasswd|j_password', decoded['data'])
 	if HTTPPasswd:
 		passw = re.findall(b'(%s=[^&]+)' % HTTPPasswd.group(0), decoded['data'], re.IGNORECASE)
 		if passw:


### PR DESCRIPTION
According to the mentioned issue, it seems that PCredz does not properly detect `password=` in an HTTP GET request because it first looks for the keyword `pass` and then tries to extract the associated value in the form of `pass=`. As a result, if the parameter is `password=`, it is not matched. I modified to regex order to match password.