### PR TITLE
Fix dockerfile "The repository does not have a Release file"

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -3,6 +3,7 @@
 FROM python:3.7.15-slim-buster
 
 # Install apt packages
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
 RUN apt update
 RUN apt install python3 \
     python3-pip \


### PR DESCRIPTION
Building the dockerfile would raise the following error, the fix was to change the repos from deb and security to archive.
```bash 
> [ 2/11] RUN apt update:                                                                                                                                                                                                                 
0.162                                                                                                                                                                                                                                       0.162 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.                                                                                                                                                       0.162                                                                                                                                                                                                                                       0.350 Ign:1 http://deb.debian.org/debian buster InRelease                                                                                                                                                                                   0.380 Ign:2 http://deb.debian.org/debian-security buster/updates InRelease 0.410 Ign:3 http://deb.debian.org/debian buster-updates InRelease 0.445 Err:4 http://deb.debian.org/debian buster Release
0.445   404  Not Found [IP: 151.101.122.132 80]
0.475 Err:5 http://deb.debian.org/debian-security buster/updates Release
0.475   404  Not Found [IP: 151.101.122.132 80]
0.509 Err:6 http://deb.debian.org/debian buster-updates Release
0.509   404  Not Found [IP: 151.101.122.132 80]
0.513 Reading package lists...
0.518 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
0.518 E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
0.518 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
------
dockerfile:6
--------------------
   4 |     
   5 |     # Install apt packages
   6 | >>> RUN apt update
   7 |     RUN apt install python3 \
   8 |         python3-pip \
--------------------
ERROR: failed to solve: process "/bin/sh -c apt update" did not complete successfully: exit code: 100
```