### PR TITLE
Update to Debian bullseye & dockerfile renaming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
-#FROM debian:buster-slim
-FROM python:3.7.15-slim-buster
+#FROM debian:bullseye-slim
+FROM python:3.9.23-slim-bullseye
 
 # Install apt packages
 RUN apt update


### PR DESCRIPTION
I have updated the base image from Debian Buster to Debian Bullseye, since the Buster security repositories are now end-of-life (EOL).
Additionally, I renamed dockerfile to Dockerfile to align with standard naming conventions and improve compatibility with Docker tooling.