### PR TITLE
Add gcc and g++ to fix pcapy-ng build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ LABEL description="PCredz - Network credential extraction tool"
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     libpcap-dev \
+    gcc \
+    g++ \
     git \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Went to build the Docker container today and got this error:
```
ERROR: failed to solve: process "/bin/sh -c pip3 install --no-cache-dir pcapy-ng" did not complete successfully: exit code: 1
```

Fixed by adding `gcc` and `g++` dependencies. Tested locally and seems good to go!