### PR TITLE
Fix live capture: replace reader.loop() with reader.next() loop

### DIFF
--- a/Pcredz
+++ b/Pcredz
@@ -667,7 +667,10 @@ def run():
     if args.interface:
         print(f'Live capture on {args.interface}\n')
         reader = pcapy.open_live(args.interface, 65536, True, 100)
-        reader.loop(-1, lambda hdr, data: process_packet(data))
+        while True:
+            header, packet = reader.next()
+            if header:
+                process_packet(packet)
         
     elif args.fname:
         process_pcap(args.fname)


### PR DESCRIPTION
reader.loop() causes TypeError/MemoryError with recent pcapy-ng versions. This aligns live capture with the same pattern already used in process_pcap().